### PR TITLE
chore: remove leftover binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+# Ignore binary artifacts
 shopify-assistant.zip
 gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## Summary
- ignore stray binary artifacts

## Testing
- `./gradlew test` *(fails: illegal escape character in SearchService and IntentParser)*


------
https://chatgpt.com/codex/tasks/task_e_68c60d83e970832cb2ec40fd3d58e40e